### PR TITLE
update frontend-plugin-core dependency to 1.6

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ resolvers += Resolver.jcenterRepo
 
 libraryDependencies ++= Seq(
   "com.eltimn"          %% "sbt-slf4j"            % "1.0.4",
-  "com.github.eirslett" %  "frontend-plugin-core" % "1.3",
+  "com.github.eirslett" %  "frontend-plugin-core" % "1.6",
   "net.liftweb"         %% "lift-common"          % "3.1.1"
 )
 

--- a/src/sbt-test/sbt-frontend/gulp/package.json
+++ b/src/sbt-test/sbt-frontend/gulp/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
   "devDependencies": {
-    "gulp": "latest"
+    "gulp": "gulpjs/gulp#c6a89f79b69742538829e66c32ca57956518be63"
   }
 }

--- a/src/sbt-test/sbt-frontend/subdir/work/package.json
+++ b/src/sbt-test/sbt-frontend/subdir/work/package.json
@@ -2,6 +2,6 @@
   "private": true,
   "devDependencies": {
     "bower": "latest",
-    "gulp": "latest"
+    "gulp": "gulpjs/gulp#c6a89f79b69742538829e66c32ca57956518be63"
   }
 }


### PR DESCRIPTION
On some linux distros / machines, we had issues downloading node and npm with the plugin. The downloaded archives ended up being corrupt. 

Updating the node/npm download location manually in our project fixed the issue:
```
nodeDownloadRoot := "https://nodejs.org/dist/",
npmDownloadRoot := "https://registry.npmjs.org/npm/-/"
```
This PR updates the frontend-plugin-core, which will make the above mentioned workaround obsolete.